### PR TITLE
sign-xpi: Python edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 apex/functions/sign-xpi/site-packages/
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+apex/functions/sign-xpi/site-packages/

--- a/apex/functions/sign-xpi/.apexignore
+++ b/apex/functions/sign-xpi/.apexignore
@@ -1,0 +1,1 @@
+*.dist-info/

--- a/apex/functions/sign-xpi/function.json
+++ b/apex/functions/sign-xpi/function.json
@@ -1,0 +1,7 @@
+{
+  "runtime": "python",
+  "description": "Example with python dependency on an external package",
+  "hooks":{
+    "build": "pip install -r requirements.txt -t ."
+  }
+}

--- a/apex/functions/sign-xpi/function.json
+++ b/apex/functions/sign-xpi/function.json
@@ -2,6 +2,6 @@
   "runtime": "python",
   "description": "Example with python dependency on an external package",
   "hooks":{
-    "build": "pip install -r requirements.txt -t ."
+    "build": "pip install -r requirements.txt -t site-packages"
   }
 }

--- a/apex/functions/sign-xpi/main.py
+++ b/apex/functions/sign-xpi/main.py
@@ -1,0 +1,27 @@
+"""
+Lambda example with external dependency
+"""
+
+import logging
+import requests
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def handle(event, context):
+    """
+    Lambda handler
+    """
+    logger.info("%s - %s", event, context)
+
+    url = "https://api.ipify.org?format=json"
+
+    raw = requests.get(url)
+    logger.info("%s", raw)
+    result = raw.json()
+
+    logger.info("Lambda IP: %s", result['ip'])
+
+    return event

--- a/apex/functions/sign-xpi/main.py
+++ b/apex/functions/sign-xpi/main.py
@@ -4,28 +4,9 @@ sign-xpi: Sign an XPI file
 
 import os.path
 import sys
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "site-packages"))
+DIR = os.path.dirname(os.path.abspath(__file__))
+SITE_PACKAGES = os.path.join(DIR, "site-packages")
+sys.path.insert(0, SITE_PACKAGES)
 
-import logging
-import requests
-
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
-
-def handle(event, context):
-    """
-    Lambda handler
-    """
-    logger.info("%s - %s", event, context)
-
-    url = "https://api.ipify.org?format=json"
-
-    raw = requests.get(url)
-    logger.info("%s", raw)
-    result = raw.json()
-
-    logger.info("Lambda IP: %s", result['ip'])
-
-    return event
+from sign_xpi import handle  # noqa: E402
+__all__ = ['handle']

--- a/apex/functions/sign-xpi/main.py
+++ b/apex/functions/sign-xpi/main.py
@@ -1,6 +1,10 @@
 """
-Lambda example with external dependency
+sign-xpi: Sign an XPI file
 """
+
+import os.path
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "site-packages"))
 
 import logging
 import requests

--- a/apex/functions/sign-xpi/requirements.txt
+++ b/apex/functions/sign-xpi/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+requests

--- a/apex/functions/sign-xpi/requirements.txt
+++ b/apex/functions/sign-xpi/requirements.txt
@@ -1,2 +1,3 @@
 boto3
+marshmallow
 requests

--- a/apex/functions/sign-xpi/sign_xpi.py
+++ b/apex/functions/sign-xpi/sign_xpi.py
@@ -1,0 +1,21 @@
+import logging
+import requests
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+def handle(event, context):
+    """
+    Lambda handler
+    """
+    logger.info("%s - %s", event, context)
+
+    url = "https://api.ipify.org?format=json"
+
+    raw = requests.get(url)
+    logger.info("%s", raw)
+    result = raw.json()
+
+    logger.info("Lambda IP: %s", result['ip'])
+
+    return event

--- a/apex/functions/sign-xpi/sign_xpi.py
+++ b/apex/functions/sign-xpi/sign_xpi.py
@@ -1,21 +1,80 @@
 import logging
-import requests
+import tempfile
+import zipfile
+
+import boto3
+import marshmallow.fields
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+s3 = boto3.resource('s3')
+
+class S3BucketInfo(marshmallow.Schema):
+    name = marshmallow.fields.String()
+    arn = marshmallow.fields.String()
+
+
+class S3ObjectInfo(marshmallow.Schema):
+    key = marshmallow.fields.String()
+
+
+class S3Path(marshmallow.Schema):
+    bucket = marshmallow.fields.Nested(S3BucketInfo)
+    object = marshmallow.fields.Nested(S3ObjectInfo)
+
+
+class S3Event(marshmallow.Schema):
+    event_time = marshmallow.fields.String(load_from="eventTime")
+    event_name = marshmallow.fields.String(load_from="eventName")
+    aws_region = marshmallow.fields.String(load_from="awsRegion")
+    s3 = marshmallow.fields.Nested(S3Path)
+
+
+class S3BatchEvent(marshmallow.Schema):
+    requests = marshmallow.fields.List(marshmallow.fields.Nested(S3Event), load_from="Records")
+
+
 def handle(event, context):
     """
-    Lambda handler
+    Handle a sign-xpi event.
     """
-    logger.info("%s - %s", event, context)
 
-    url = "https://api.ipify.org?format=json"
+    event = S3BatchEvent(strict=True).load(event).data
+    responses = []
+    for request in event['requests']:
+        filename = request['s3']['object']['key']
+        if not filename.endswith(u'.xpi'):
+            responses.append({"error": "file not XPI: {}".format(filename)})
+            continue
 
-    raw = requests.get(url)
-    logger.info("%s", raw)
-    result = raw.json()
+        if not request['event_name'].startswith(u'ObjectCreated'):
+            responses.append({"error": "event not ObjectCreated: {}".format(request['event_name'])})
+            continue
 
-    logger.info("Lambda IP: %s", result['ip'])
+        bucket_name = request['s3']['bucket']['name']
+        bucket = s3.Bucket(bucket_name)
+        with tempfile.TemporaryFile() as localfile:
+            bucket.download_fileobj(filename, localfile)
 
-    return event
+            xpi = zipfile.ZipFile(localfile)
+
+            manifest_name = None
+            xpi_files = xpi.namelist()
+            for possible_manifest in ['install.rdf', 'manifest.json']:
+                if possible_manifest in xpi_files:
+                    manifest_name = possible_manifest
+                    break
+
+            if not manifest_name:
+                responses.append({"error": "No manifest found in {}".format(filename)})
+                break
+
+            manifest_contents = xpi.read(manifest_name)
+
+        logger.info("Manifest for %s: %s", filename, manifest_name)
+        logger.info("%s", manifest_contents)
+        # FIXME: point to some other XPI
+        responses.append({"uploaded": request['s3']})
+
+    return responses


### PR DESCRIPTION
This is similar to #6 (and probably obsoletes it). It was much easier to crank out because I didn't have to mess around with building OpenSSL or Musl or anything.

Some annoyances I encountered:

- Apex makes no effort whatsoever to let you run your code outside of Lambda. On the other hand, building a zip file and uploading it to Lambda for every change is a little exasperating (especially on a slow ADSL connection like I have). Probably the right move here is to have your `handle` function be as thin as possible a wrapper around something that you can run locally (perhaps using `if __name__ == '__main__'`).
- The default Apex example lets you depend on external packages, but they get installed willy-nilly in your local directory rather than someplace sensible (like a venv or a site-packages directory). You can fix this yourself (as I did in this PR), but it's a little ugly.
- If your Python script throws an exception when invoked using `apex invoke`, Apex fails to parse the exception, and you get a "cannot unmarshal array into Go value of type string" error. Then you have to use `apex logs` to see the stack trace, but the latency on the logs is enough that it can be a bit annoying to do that too.
